### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## My Event Planner (Sample App)
 
-This repo contains sample app code to accompany [AWS Workshop Studio](workshops.aws/) labs.   
+This repo contains sample app code to accompany [AWS Workshop Studio](https://catalog.us-east-1.prod.workshops.aws/workshops/1665a9b6-958b-4b70-ba52-14127b8fa99f/en-US) labs.   
 The sample app is an event planning app for students on campus.   
 Students can create events that other students can browse.   
 


### PR DESCRIPTION
Adding link to the Workshop studio lab

*Issue #, if available:*
> The readme has the following reference which is not operational - 

This repo contains sample app code to accompany `[AWS Workshop Studio](workshops.aws/)` labs.

*Description of changes:*

> Replacing it with

This repo contains sample app code to accompany `[AWS Workshop Studio](https://catalog.us-east-1.prod.workshops.aws/workshops/1665a9b6-958b-4b70-ba52-14127b8fa99f/en-US)` labs.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
